### PR TITLE
Add argument

### DIFF
--- a/naoqi_apps/launch/background_movement.launch
+++ b/naoqi_apps/launch/background_movement.launch
@@ -7,7 +7,8 @@
 
   <arg name="nao_ip" default="$(optenv NAO_IP 127.0.0.1)" />
   <arg name="nao_port" default="$(optenv NAO_PORT 9559)" />
+  <arg name="user" default="nao" />
   <arg name="password" default="no_password" />
   
-  <node pkg="naoqi_apps" type="naoqi_background_movement.py" name="naoqi_background_movement" required="true" args="--pip=$(arg nao_ip) --pport=$(arg nao_port) --password=$(arg password)"  />
+  <node pkg="naoqi_apps" type="naoqi_background_movement.py" name="naoqi_background_movement" required="true" args="--pip=$(arg nao_ip) --pport=$(arg nao_port) --user=$(arg user) --password=$(arg password)"  />
 </launch>

--- a/naoqi_apps/launch/background_movement.launch
+++ b/naoqi_apps/launch/background_movement.launch
@@ -7,6 +7,7 @@
 
   <arg name="nao_ip" default="$(optenv NAO_IP 127.0.0.1)" />
   <arg name="nao_port" default="$(optenv NAO_PORT 9559)" />
+  <arg name="password" default="no_password" />
   
-  <node pkg="naoqi_apps" type="naoqi_background_movement.py" name="naoqi_background_movement" required="true" args="--pip=$(arg nao_ip) --pport=$(arg nao_port)"  />
+  <node pkg="naoqi_apps" type="naoqi_background_movement.py" name="naoqi_background_movement" required="true" args="--pip=$(arg nao_ip) --pport=$(arg nao_port) --password=$(arg password)"  />
 </launch>

--- a/naoqi_apps/launch/gaze_analysis.launch
+++ b/naoqi_apps/launch/gaze_analysis.launch
@@ -7,6 +7,7 @@
 
   <arg name="nao_ip" default="$(optenv NAO_IP 127.0.0.1)" />
   <arg name="nao_port" default="$(optenv NAO_PORT 9559)" />
+  <arg name="password" default="no_password" />
   
-  <node pkg="naoqi_apps" type="naoqi_gaze_analysis.py" name="naoqi_gaze_analysis" required="true" args="--pip=$(arg nao_ip) --pport=$(arg nao_port)"  />
+  <node pkg="naoqi_apps" type="naoqi_gaze_analysis.py" name="naoqi_gaze_analysis" required="true" args="--pip=$(arg nao_ip) --pport=$(arg nao_port) --password=$(arg password)"  />
 </launch>

--- a/naoqi_apps/launch/gaze_analysis.launch
+++ b/naoqi_apps/launch/gaze_analysis.launch
@@ -7,7 +7,8 @@
 
   <arg name="nao_ip" default="$(optenv NAO_IP 127.0.0.1)" />
   <arg name="nao_port" default="$(optenv NAO_PORT 9559)" />
+  <arg name="user" default="nao" />
   <arg name="password" default="no_password" />
   
-  <node pkg="naoqi_apps" type="naoqi_gaze_analysis.py" name="naoqi_gaze_analysis" required="true" args="--pip=$(arg nao_ip) --pport=$(arg nao_port) --password=$(arg password)"  />
+  <node pkg="naoqi_apps" type="naoqi_gaze_analysis.py" name="naoqi_gaze_analysis" required="true" args="--pip=$(arg nao_ip) --pport=$(arg nao_port) --user=$(arg user) --password=$(arg password)"  />
 </launch>

--- a/naoqi_apps/launch/listening_movement.launch
+++ b/naoqi_apps/launch/listening_movement.launch
@@ -7,6 +7,7 @@
 
   <arg name="nao_ip" default="$(optenv NAO_IP 127.0.0.1)" />
   <arg name="nao_port" default="$(optenv NAO_PORT 9559)" />
+  <arg name="password" default="no_password" />
   
-  <node pkg="naoqi_apps" type="naoqi_listening_movement.py" name="naoqi_listening_movement" required="true" args="--pip=$(arg nao_ip) --pport=$(arg nao_port)"  />
+  <node pkg="naoqi_apps" type="naoqi_listening_movement.py" name="naoqi_listening_movement" required="true" args="--pip=$(arg nao_ip) --pport=$(arg nao_port)  --password=$(arg password)"  />
 </launch>

--- a/naoqi_apps/launch/listening_movement.launch
+++ b/naoqi_apps/launch/listening_movement.launch
@@ -7,7 +7,8 @@
 
   <arg name="nao_ip" default="$(optenv NAO_IP 127.0.0.1)" />
   <arg name="nao_port" default="$(optenv NAO_PORT 9559)" />
+  <arg name="user" default="nao" />
   <arg name="password" default="no_password" />
   
-  <node pkg="naoqi_apps" type="naoqi_listening_movement.py" name="naoqi_listening_movement" required="true" args="--pip=$(arg nao_ip) --pport=$(arg nao_port)  --password=$(arg password)"  />
+  <node pkg="naoqi_apps" type="naoqi_listening_movement.py" name="naoqi_listening_movement" required="true" args="--pip=$(arg nao_ip) --pport=$(arg nao_port) --user=$(arg user) --password=$(arg password)"  />
 </launch>


### PR DESCRIPTION
related to https://github.com/ros-naoqi/naoqi_bridge/pull/98

I confirmed that this works as followed (Ubuntu 20.04, ROS noetic):

Pepper (Naoqi 2.9)
```
roslaunch naoqi_apps background_movement.launch nao_port:=9503 password:=<password>
```

NAO (Naoqi maybe 2.6)
```
roslaunch naoqi_apps background_movement.launch 
```